### PR TITLE
Fix pagination with no joins in PaginatorExtension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2023-12-20
+### Fixed
+* Fixed PaginationExtension for queries without joins
+
 ## 2023-12-11
 ### Fixed
 * Fixed pagination for queries without joins

--- a/src/Extension/PaginationExtension.php
+++ b/src/Extension/PaginationExtension.php
@@ -126,7 +126,11 @@ final class PaginationExtension implements QueryResultCollectionExtension
         $metadata = $this->managerRegistry->getManagerForClass($operationClassName)?->getClassMetadata();
         if (!is_null($metadata)) {
             $rootAlias = $selectBuilder->getRootAlias();
-            foreach ($selectBuilder->getJoins()[$rootAlias] as $join) {
+            $joins = $selectBuilder->getJoins();
+            if(empty($joins)) {
+                return false;
+            }
+            foreach ($joins[$rootAlias] as $join) {
                 $joinData = explode('.', $join->join);
                 $mapping = $metadata->getAssociationMapping($joinData[1]);
                 if ($mapping['type'] === AssociationType::TO_MANY) {


### PR DESCRIPTION
I experienced an issue when I tried the built in collection getter of ApiPlatform.

```json
  "@id": "/api/errors/500",
  "@type": "hydra:Error",
  "title": "An error occurred",
  "detail": "Warning: Undefined array key \"o\"",
  "status": 500,
  "type": "/errors/500",
  "trace": [
    {
      "file": "/app/vendor/ccmbenchmark/ting-api-platform/src/Extension/PaginationExtension.php",
      "line": 110,
      "function": "containsAtLeastOneJoinToMany",
      "class": "CCMBenchmark\\Ting\\ApiPlatform\\Extension\\PaginationExtension",
      "type": "->"
    },
    {
      "file": "/app/vendor/ccmbenchmark/ting-api-platform/src/Extension/PaginationExtension.php",
      "line": 89,
      "function": "hasAdditionalDistinctQueryRequirement",
      "class": "CCMBenchmark\\Ting\\ApiPlatform\\Extension\\PaginationExtension",
      "type": "->"
    },
    {
      "file": "/app/vendor/ccmbenchmark/ting-api-platform/src/State/CollectionProvider.php",
      "line": 84,
      "function": "getResult",
      "class": "CCMBenchmark\\Ting\\ApiPlatform\\Extension\\PaginationExtension",
      "type": "->"
    },
  ...
]
```

It seems that the method `containsAtLeastOneJoinToMany` of the class `CCMBenchmark\Ting\ApiPlatform\Extension\PaginatorExtension` can't handle a query with no join in it.