### PR TITLE
fix(FilterCompilerPass):fix the issue where the FilterCompilerPass wo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024-01-25
+### Fixed
+* Fixed FilterCompilerPass trying to add method call setFilterDescriptionGetter() to Api Platform filter services not implementing it
+
 ## 2024-01-18
 * Supports fetchEager API property and forceEager on operation
 

--- a/src/DependencyInjection/FilterCompilerPass.php
+++ b/src/DependencyInjection/FilterCompilerPass.php
@@ -2,12 +2,18 @@
 
 namespace CCMBenchmark\Ting\ApiPlatform\DependencyInjection;
 
+use CCMBenchmark\Ting\ApiPlatform\Filter\WarmableFilterInterface;
 use CCMBenchmark\Ting\ApiPlatform\Warmer\FilterWarmer;
 use CCMBenchmark\Ting\ApiPlatform\DependencyInjection\FilterDescriptionGetter;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Reference;
+
+use function array_filter;
+use function array_walk;
+use function is_a;
+use function is_null;
 
 class FilterCompilerPass implements CompilerPassInterface
 {
@@ -16,6 +22,10 @@ class FilterCompilerPass implements CompilerPassInterface
         $warmer = $container->findDefinition(FilterWarmer::class);
 
         $filterServices = $container->findTaggedServiceIds('api_platform.filter');
+        $filterServices = array_filter($filterServices, function($serviceId) use ($container) {
+            $serviceClass = $container->getDefinition($serviceId)->getClass();
+            return is_null($serviceClass) === false && is_a($serviceClass, WarmableFilterInterface::class, true);
+        }, ARRAY_FILTER_USE_KEY);
         array_walk($filterServices, fn(array &$tagParams, string $serviceId) => $tagParams = new Reference($serviceId));
 
         $warmer

--- a/src/State/PersistProcessor.php
+++ b/src/State/PersistProcessor.php
@@ -11,6 +11,7 @@ use CCMBenchmark\Ting\ApiPlatform\Ting\ManagerRegistry;
 use function is_object;
 
 /**
+ * @phpstan-ignore-next-line
  * @template T of object
  * @implements ProcessorInterface<T>
  * TODO: Handle PUT requests

--- a/src/State/RemoveProcessor.php
+++ b/src/State/RemoveProcessor.php
@@ -11,8 +11,9 @@ use CCMBenchmark\Ting\ApiPlatform\Ting\ManagerRegistry;
 use function is_object;
 
 /**
+ * @phpstan-ignore-next-line
  * @template T of object
- * @implements ProcessorInterface<void>
+ * @implements ProcessorInterface<T>
  */
 final class RemoveProcessor implements ProcessorInterface
 {
@@ -21,6 +22,7 @@ final class RemoveProcessor implements ProcessorInterface
     }
 
     /**
+     * @param T $data
      * @param Operation<T>         $operation
      * @param array<string, mixed> $uriVariables
      * @param array<string, mixed> $context


### PR DESCRIPTION
I encountered an issue where the `CCMBenchmark\Ting\ApiPlatform\DependencyInjection\FilterCompilerPass` class would try to add the call to the method `setFilterDescriptionGetter()` to Api Platform filter services not implementing it such as  `ApiPlatform\Elasticsearch\Filter\MatchFilter` or `ApiPlatform\Elasticsearch\Filter\TermFilter`

Trying to use them will display this error:
![FilterCompilerPass issue](https://github.com/ccmbenchmark/ting_api_platform/assets/49196540/0dcf30c0-16c2-4386-866d-7910d4587ad4)

