### PR TITLE
Add aura/sqlquery dependency to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "require": {
         "php": ">=8.1",
         "api-platform/core": "^3.2",
+        "aura/sqlquery": "^2.6",
         "ccmbenchmark/ting_bundle": "^3.6",
         "ccmbenchmark/ting": "^3.8.0"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -26,11 +26,6 @@ parameters:
 			path: src/Extension/FilterEagerLoadingExtension.php
 
 		-
-			message: "#^Method CCMBenchmark\\\\Ting\\\\ApiPlatform\\\\Extension\\\\PaginationExtension\\:\\:getResult\\(\\) should return array\\|CCMBenchmark\\\\Ting\\\\ApiPlatform\\\\PartialPaginator\\<T of object\\> but returns CCMBenchmark\\\\Ting\\\\ApiPlatform\\\\Paginator\\<object\\>\\.$#"
-			count: 1
-			path: src/Extension/PaginationExtension.php
-
-		-
 			message: "#^Cannot call method getClassMetadata\\(\\) on CCMBenchmark\\\\Ting\\\\ApiPlatform\\\\Ting\\\\Manager\\<T of object\\>\\|null\\.$#"
 			count: 1
 			path: src/Filter/AbstractFilter.php

--- a/src/Warmer/FilterWarmer.php
+++ b/src/Warmer/FilterWarmer.php
@@ -23,11 +23,7 @@ class FilterWarmer implements CacheWarmerInterface
         return false;
     }
 
-    /**
-     * @param string $cacheDir
-     * @return string[]
-     */
-    public function warmUp(string $cacheDir)
+    public function warmUp(string $cacheDir, ?string $buildDir = null): array
     {
         $cacheDir .= '/ting_api_platform';
         if (!file_exists($cacheDir)) {


### PR DESCRIPTION
ting_api_platform n'est pas compatible avec aura/sqlquery version 3

L'interface SubselectInterface n'existe plus dans la version 3
Utilisé dans src/Ting/Query/SelectBuilder.php